### PR TITLE
- usage of smarty names message_erreur/themeForm to have compatibilit…

### DIFF
--- a/admin/broken.php
+++ b/admin/broken.php
@@ -78,7 +78,7 @@ switch ($op) {
                 unset($broken);
             }
         } else {
-            $GLOBALS['xoopsTpl']->assign('error', _AM_TDMDOWNLOADS_ERREUR_NOBROKENDOWNLOADS);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', _AM_TDMDOWNLOADS_ERREUR_NOBROKENDOWNLOADS);
         }
         break;
     // permet de suprimmer le rapport de téléchargment brisé
@@ -91,7 +91,7 @@ switch ($op) {
             if ($brokenHandler->delete($obj)) {
                 redirect_header('broken.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         } else {
             //Affichage de la partie haute de l'administration de Xoops
             xoops_cp_header();

--- a/admin/category.php
+++ b/admin/category.php
@@ -75,7 +75,7 @@ switch ($op) {
         //Affichage du formulaire de création des catégories
         $obj  = $categoryHandler->create();
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour éditer une catégorie
     case 'edit_cat':
@@ -92,7 +92,7 @@ switch ($op) {
         /** @var \XoopsModules\Tdmdownloads\Category $obj */
         $obj  = $categoryHandler->get($categoryId);
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour supprimer une catégorie
     case 'del_cat':
@@ -236,7 +236,7 @@ switch ($op) {
             if ($categoryHandler->delete($obj)) {
                 redirect_header('category.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
             } else {
-                $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+                $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
             }
         } else {
             $message  = '';
@@ -338,7 +338,7 @@ switch ($op) {
             }
         }
         if (true === $erreur) {
-            $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
         } else {
             if ($categoryHandler->insert($obj)) {
                 $newcat_cid = $obj->getNewEnreg($db);
@@ -394,10 +394,10 @@ switch ($op) {
                 }
                 redirect_header('category.php?op=list', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         }
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
 }
 

--- a/admin/downloads.php
+++ b/admin/downloads.php
@@ -173,7 +173,7 @@ switch ($op) {
                 unset($download);
             }
         } else {
-            $GLOBALS['xoopsTpl']->assign('error', _AM_TDMDOWNLOADS_ERREUR_NODOWNLOADSWAITING);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', _AM_TDMDOWNLOADS_ERREUR_NODOWNLOADSWAITING);
         }
         break;
     // vue création
@@ -194,7 +194,7 @@ switch ($op) {
         /** @var \XoopsModules\Tdmdownloads\Downloads $obj */
         $obj  = $downloadsHandler->create();
         $form = $obj->getForm($donnee = [], false);
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour éditer un téléchargement
     case 'edit_downloads':
@@ -215,7 +215,7 @@ switch ($op) {
         $downloads_lid = \Xmf\Request::getInt('downloads_lid', 0, 'GET');
         $obj           = $downloadsHandler->get($downloads_lid);
         $form          = $obj->getForm($donnee = [], false);
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour supprimer un téléchargement
     case 'del_downloads':
@@ -276,7 +276,7 @@ switch ($op) {
                 }
                 redirect_header('downloads.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
             } else {
-                $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+                $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
             }
         } else {
             //Affichage de la partie haute de l'administration de Xoops
@@ -479,9 +479,9 @@ switch ($op) {
                     redirect_header('downloads.php?op=view_downloads&downloads_lid=' . \Xmf\Request::getInt('lid'), 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
                 }
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         }
-        $GLOBALS['xoopsTpl']->assign('error', $objvotedata->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $objvotedata->getHtmlErrors());
         break;
     // Pour sauver un téléchargement
     case 'save_downloads':
@@ -594,9 +594,9 @@ switch ($op) {
 
         if (1 == $erreur) {
             xoops_cp_header();
-            $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
             $form = $obj->getForm($donnee, true);
-            $GLOBALS['xoopsTpl']->assign('form', $form->render());
+            $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
             break;
         } else {
             $obj->setVar('size', \Xmf\Request::getInt('size', 0, 'POST') . ' ' . \Xmf\Request::getString('type_size', '', 'POST'));
@@ -610,9 +610,9 @@ switch ($op) {
                     $uploader->fetchMedia($_POST['xoops_upload_file'][0]);
                     if (!$uploader->upload()) {
                         $errorMessage .= $uploader->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     } else {
                         $obj->setVar('url', $uploadurl_downloads . $uploader->getSavedFileName());
@@ -621,9 +621,9 @@ switch ($op) {
                     if ( '' < $_FILES['attachedfile']['name'] ) { 
                         // file name was given, but fetchMedia failed - show error when e.g. file size exceed maxuploadsize
                         $errorMessage .= $uploader->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     }
                     $obj->setVar('url', \Xmf\Request::getUrl('url', '', 'POST'));
@@ -643,9 +643,9 @@ switch ($op) {
                     $uploader_2->fetchMedia($_POST['xoops_upload_file'][1]);
                     if (!$uploader_2->upload()) {
                         $errorMessage .= $uploader_2->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     } else {
                         $obj->setVar('logourl', $uploader_2->getSavedFileName());
@@ -654,9 +654,9 @@ switch ($op) {
                     if ( '' < $_FILES['attachedimage']['name'] ) { 
                         // file name was given, but fetchMedia failed - show error when e.g. file size exceed maxuploadsize
                         $errorMessage .= $uploader_2->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     }
                     $obj->setVar('logourl', \Xmf\Request::getString('logo_img', '', 'POST'));
@@ -729,10 +729,10 @@ switch ($op) {
                 }
                 redirect_header('downloads.php', 2, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         }
         $form = $obj->getForm($donnee, true);
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // permet de valider un téléchargement proposé
     case 'update_status':
@@ -741,7 +741,7 @@ switch ($op) {
         if ($downloadsHandler->insert($obj)) {
             redirect_header('downloads.php', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
         }
-        $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         break;
     // permet de valider un téléchargement proposé
     case 'lock_status':
@@ -750,7 +750,7 @@ switch ($op) {
         if ($downloadsHandler->insert($obj)) {
             redirect_header('downloads.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DEACTIVATED);
         }
-        $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         break;
 }
 

--- a/admin/field.php
+++ b/admin/field.php
@@ -67,7 +67,7 @@ switch ($op) {
         if ($fieldHandler->insert($obj)) {
             redirect_header('field.php?op=list', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
         }
-        $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         break;
     case 'update_search':
         $obj = $fieldHandler->get(\Xmf\Request::getInt('fid', 0, 'REQUEST'));
@@ -76,7 +76,7 @@ switch ($op) {
         if ($fieldHandler->insert($obj)) {
             redirect_header('field.php?op=list', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
         }
-        $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         break;
     // vue création
     case 'new_field':
@@ -90,7 +90,7 @@ switch ($op) {
         //Affichage du formulaire de création des champs
         $obj  = $fieldHandler->create();
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour éditer un champ
     case 'edit_field':
@@ -105,7 +105,7 @@ switch ($op) {
         //Affichage du formulaire de création des champs
         $obj  = $fieldHandler->get(\Xmf\Request::getInt('fid', 0, 'GET'));
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
     // Pour supprimer un champ
     case 'del_field':
@@ -127,7 +127,7 @@ switch ($op) {
             if ($fieldHandler->delete($obj)) {
                 redirect_header('field.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
             } else {
-                $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+                $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
             }
         } else {
             $downloadsfield = $fieldHandler->get(\Xmf\Request::getInt('fid', 0, 'GET'));
@@ -202,15 +202,15 @@ switch ($op) {
             $errorMessage = _AM_TDMDOWNLOADS_ERREUR_WEIGHT . '<br>';
         }
         if (true === $erreur) {
-            $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
         } else {
             if ($fieldHandler->insert($obj)) {
                 redirect_header('field.php', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         }
         $form = $obj->getForm();
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
         break;
 }
 

--- a/admin/import.php
+++ b/admin/import.php
@@ -346,7 +346,7 @@ switch ($op) {
             $form->addElement(new \XoopsFormHidden('op', 'cancel'));
             $form->addElement(new \XoopsFormButton('', 'submit', _CANCEL, 'submit'));
         }
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
 
         break;
     // import WF-Downloads
@@ -397,7 +397,7 @@ switch ($op) {
             $form->addElement(new \XoopsFormHidden('op', 'cancel'));
             $form->addElement(new \XoopsFormButton('', 'submit', _CANCEL, 'submit'));
         }
-        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
 
         break;
 }

--- a/admin/modified.php
+++ b/admin/modified.php
@@ -78,7 +78,7 @@ switch ($op) {
                 unset($modified);
             }
         } else {
-            $GLOBALS['xoopsTpl']->assign('error', _AM_TDMDOWNLOADS_ERREUR_NOBMODDOWNLOADS);
+            $GLOBALS['xoopsTpl']->assign('message_erreur', _AM_TDMDOWNLOADS_ERREUR_NOBMODDOWNLOADS);
         }
         break;
     // show a comparision of the versions
@@ -210,7 +210,7 @@ switch ($op) {
             if ($modifiedHandler->delete($obj)) {
                 redirect_header('modified.php', 1, _AM_TDMDOWNLOADS_REDIRECT_DELOK);
             }
-            $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+            $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         } else {
             $GLOBALS['xoopsTpl']->assign('navigation', $adminObject->displayNavigation(basename(__FILE__)));
             $adminObject->addItemButton(_MI_TDMDOWNLOADS_ADMENU5, 'modified.php', 'list');
@@ -301,7 +301,7 @@ switch ($op) {
         if ($downloadsHandler->insert($obj)) {
             redirect_header('modified.php', 1, _AM_TDMDOWNLOADS_REDIRECT_SAVE);
         }
-        $GLOBALS['xoopsTpl']->assign('error', $obj->getHtmlErrors());
+        $GLOBALS['xoopsTpl']->assign('message_erreur', $obj->getHtmlErrors());
         break;
 }
 

--- a/blocks/tdmdownloads_top.php
+++ b/blocks/tdmdownloads_top.php
@@ -40,7 +40,7 @@ function b_tdmdownloads_top_show($options)
     $use_description    = $options[4];
     $show_inforation    = $options[5];
     $logo_float         = $options[6];
-    $logo_white         = $options[7];
+    $logo_width         = $options[7];
     $lenght_description = $options[8];
 
     array_shift($options);
@@ -60,6 +60,7 @@ function b_tdmdownloads_top_show($options)
     $xoTheme->addStylesheet(XOOPS_URL . '/modules/' . $moduleDirName . '/assets/css/blocks.css', null);
     /** @var \XoopsModules\Tdmdownloads\Utility $utility */
     $utility = new \XoopsModules\Tdmdownloads\Utility();
+	$helper->loadLanguage('main');
 
     $categories = $utility->getItemIds('tdmdownloads_view', $moduleDirName);
     $criteria   = new \CriteriaCompo();
@@ -94,7 +95,7 @@ function b_tdmdownloads_top_show($options)
         $block[$i]['lid']   = $downloadsArray[$i]->getVar('lid');
         $block[$i]['title'] = mb_strlen($downloadsArray[$i]->getVar('title')) > $lenght_title ? mb_substr($downloadsArray[$i]->getVar('title'), 0, $lenght_title) . '...' : $downloadsArray[$i]->getVar('title');
         $descriptionShort  = '';
-        if (true === $use_description) {
+        if (true == $use_description) {
             $description = $downloadsArray[$i]->getVar('description');
             //permet d'afficher uniquement la description courte
             if (false === mb_strpos($description, '[pagebreak]')) {
@@ -105,7 +106,7 @@ function b_tdmdownloads_top_show($options)
         }
         $block[$i]['description'] = $descriptionShort;
         $logourl                  = '';
-        if (true === $use_logo) {
+        if (true == $use_logo) {
             if ('blank.gif' === $downloadsArray[$i]->getVar('logourl')) {
                 $logourl = '';
             } else {
@@ -114,7 +115,7 @@ function b_tdmdownloads_top_show($options)
         }
         $block[$i]['logourl']       = $logourl;
         $block[$i]['logourl_class'] = $logo_float;
-        $block[$i]['logourl_width'] = $logo_white;
+        $block[$i]['logourl_width'] = $logo_width;
         $block[$i]['hits']          = $downloadsArray[$i]->getVar('hits');
         $block[$i]['rating']        = number_format($downloadsArray[$i]->getVar('rating'), 1);
         $block[$i]['date']          = formatTimestamp($downloadsArray[$i]->getVar('date'), 's');
@@ -143,7 +144,7 @@ function b_tdmdownloads_top_edit($options)
     $form              .= '<input type="hidden" name="options[0]" value="' . $options[0] . "\">\n";
     $form              .= '<input name="options[1]" size="5" maxlength="255" value="' . $options[1] . '" type="text">&nbsp;' . _MB_TDMDOWNLOADS_FILES . "<br>\n";
     $form              .= _MB_TDMDOWNLOADS_CHARS . ' : <input name="options[2]" size="5" maxlength="255" value="' . $options[2] . "\" type=\"text\"><br>\n";
-    if (false === $options[3]) {
+    if (false == $options[3]) {
         $checked_yes = '';
         $checked_no  = 'checked';
     } else {
@@ -152,7 +153,7 @@ function b_tdmdownloads_top_edit($options)
     }
     $form .= _MB_TDMDOWNLOADS_LOGO . ' : <input name="options[3]" value="1" type="radio" ' . $checked_yes . '>' . _YES . "&nbsp;\n";
     $form .= '<input name="options[3]" value="0" type="radio" ' . $checked_no . '>' . _NO . "<br>\n";
-    if (false === $options[4]) {
+    if (false == $options[4]) {
         $checked_yes = '';
         $checked_no  = 'checked';
     } else {
@@ -161,7 +162,7 @@ function b_tdmdownloads_top_edit($options)
     }
     $form .= _MB_TDMDOWNLOADS_DESCRIPTION . ' : <input name="options[4]" value="1" type="radio" ' . $checked_yes . '>' . _YES . "&nbsp;\n";
     $form .= '<input name="options[4]" value="0" type="radio" ' . $checked_no . '>' . _NO . "<br>\n";
-    if (false === $options[5]) {
+    if (false == $options[5]) {
         $checked_yes = '';
         $checked_no  = 'checked';
     } else {

--- a/brokenfile.php
+++ b/brokenfile.php
@@ -68,7 +68,7 @@ switch ($op) {
         //Affichage du formulaire de fichier brisé*/
         $obj  = $brokenHandler->create();
         $form = $obj->getForm($lid);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
         break;
     // save
     case 'save':
@@ -111,7 +111,7 @@ switch ($op) {
         $obj->setVar('sender', $ratinguser);
         $obj->setVar('ip', getenv('REMOTE_ADDR'));
         if (true === $erreur) {
-            $xoopsTpl->assign('error', $errorMessage);
+            $xoopsTpl->assign('message_erreur', $errorMessage);
         } else {
             if ($brokenHandler->insert($obj)) {
                 $tags                      = [];
@@ -125,7 +125,7 @@ switch ($op) {
         }
         //Affichage du formulaire de notation des téléchargements
         $form = $obj->getForm($lid);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
 
         break;
 }

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -44,6 +44,9 @@
 - fixed bug for checking category (goffy)
 - transformed preference maxuploadsize from text to array (goffy)
 - fixed bug block editing (goffy)
+- usage of smarty names message_erreur/themeForm to have compatibility with existing themes (goffy)
+- adopted modfile.tpl (caused error if used together with blocks) (goffy)
+- skip captcha for xoopsUsers (members are skipped in class/download.php getForm)  (goffy)
 
 TODO:
 - add test data

--- a/language/english/admin.php
+++ b/language/english/admin.php
@@ -38,8 +38,8 @@ define('_AM_TDMDOWNLOADS_DOWNLOADS_WAIT', 'Waiting for approval');
 define('_AM_TDMDOWNLOADS_BROKEN_SENDER', 'Report Author');
 define('_AM_TDMDOWNLOADS_BROKEN_SURDEL', 'Are you sure you want to delete this report?');
 //modified.php
-define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Submitted by:');
-define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Original');
+define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Modified version');
+define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Original version');
 define('_AM_TDMDOWNLOADS_MODIFIED_SURDEL', 'Are you sure to delete this download modification request?');
 //field.php
 define('_AM_TDMDOWNLOADS_DELDATA', 'With the following data:');

--- a/language/french/admin.php
+++ b/language/french/admin.php
@@ -38,8 +38,8 @@ define('_AM_TDMDOWNLOADS_DOWNLOADS_WAIT', 'En attente de validation');
 define('_AM_TDMDOWNLOADS_BROKEN_SENDER', "Signaler à l'auteur");
 define('_AM_TDMDOWNLOADS_BROKEN_SURDEL', 'Êtes-vous sûr de que vouloir supprimer ce rapport ?');
 //modified.php
-define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Soumis par :');
-define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Original');
+define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Version modifiée');
+define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Version originale');
 define('_AM_TDMDOWNLOADS_MODIFIED_SURDEL', 'Êtes-vous sûr de vouloir supprimer cette demande de modification de téléchargement ?');
 //field.php
 define('_AM_TDMDOWNLOADS_DELDATA', 'Avec les données suivantes :');

--- a/language/german/admin.php
+++ b/language/german/admin.php
@@ -38,8 +38,8 @@ define('_AM_TDMDOWNLOADS_DOWNLOADS_WAIT', 'Warten auf Freigabe');
 define('_AM_TDMDOWNLOADS_BROKEN_SENDER', 'Meldende Person');
 define('_AM_TDMDOWNLOADS_BROKEN_SURDEL', 'Sind Sie sicher, dass Sie diese Meldung löschen wollen?');
 //modified.php
-define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Eingesendet von:');
-define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Original');
+define('_AM_TDMDOWNLOADS_MODIFIED_MOD', 'Abgeänderte Version');
+define('_AM_TDMDOWNLOADS_MODIFIED_ORIGINAL', 'Originalversion');
 define('_AM_TDMDOWNLOADS_MODIFIED_SURDEL', 'Sind Sie sicher, dass Sie diesen Änderungsantrag löschen wollen?');
 //field.php
 define('_AM_TDMDOWNLOADS_DELDATA', 'mit folgenden Daten:');

--- a/ratefile.php
+++ b/ratefile.php
@@ -69,7 +69,7 @@ switch ($op) {
         //Affichage du formulaire de notation des téléchargements
         $obj  = $ratingHandler->create();
         $form = $obj->getForm($lid);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
         break;
     // save
     case 'save':
@@ -130,7 +130,7 @@ switch ($op) {
         $obj->setVar('ratinghostname', getenv('REMOTE_ADDR'));
         $obj->setVar('ratingtimestamp', time());
         if (true === $erreur) {
-            $xoopsTpl->assign('error', $errorMessage);
+            $xoopsTpl->assign('message_erreur', $errorMessage);
         } else {
             if ($ratingHandler->insert($obj)) {
                 $criteria = new \CriteriaCompo();
@@ -154,7 +154,7 @@ switch ($op) {
         }
         //Affichage du formulaire de notation des téléchargements
         $form = $obj->getForm($lid);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
 
         break;
 }

--- a/search.php
+++ b/search.php
@@ -229,7 +229,7 @@ foreach (array_keys($tdmdownloadsArray) as $i) {
     $contenu                    = '';
     foreach (array_keys($downloads_field) as $j) {
         if (1 == $downloads_field[$j]->getVar('status_def')) {
-            if (1 === $downloads_field[$j]->getVar('fid')) {
+            if (1 == $downloads_field[$j]->getVar('fid')) {
                 //page d'accueil
                 $contenu = $tdmdownloadsArray[$i]->getVar('homepage');
             }
@@ -259,13 +259,16 @@ foreach (array_keys($tdmdownloadsArray) as $i) {
                 $contenu = '';
             }
         }
+		
+		
         $tdmdownloadsTab['fielddata'][$j] = $contenu;
         unset($contenu);
     }
-    $xoopsTpl->append('downloads', $tdmdownloadsTab);
+    $xoopsTpl->append('search_list', $tdmdownloadsTab);
 
     $keywords .= $tdmdownloadsArray[$i]->getVar('title') . ',';
 }
+
 $xoopsTpl->assign('searchForm', $form->render());
 // référencement
 // titre de la page

--- a/submit.php
+++ b/submit.php
@@ -50,15 +50,15 @@ switch ($op) {
         //Affichage du formulaire de notation des téléchargements
         $obj  = $downloadsHandler->create();
         $form = $obj->getForm($donnee = [], false);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
         break;
     // save
     case 'save_downloads':
         require_once XOOPS_ROOT_PATH . '/class/uploader.php';
-        $obj            = $downloadsHandler->create();
-        $erreur         = false;
+        $obj          = $downloadsHandler->create();
+        $erreur       = false;
         $errorMessage = '';
-        $donnee         = [];
+        $donnee       = [];
         $obj->setVar('title', \Xmf\Request::getString('title', '', 'POST'));
         $donnee['title'] = \Xmf\Request::getString('title', '', 'POST');
         $obj->setVar('cid', \Xmf\Request::getString('cid', '', 'POST'));
@@ -139,9 +139,9 @@ switch ($op) {
             $donnee['TAG'] = $_POST['tag'];
         }
         if (true === $erreur) {
-            $xoopsTpl->assign('error', $errorMessage);
+            $xoopsTpl->assign('message_erreur', $errorMessage);
             $form = $obj->getForm($donnee, true);
-            $GLOBALS['xoopsTpl']->assign('form', $form->render());
+            $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
             break;
         } else {
             $obj->setVar('size', \Xmf\Request::getString('size', '', 'POST') . ' ' . \Xmf\Request::getString('type_size', '', 'POST'));
@@ -163,9 +163,9 @@ switch ($op) {
                     if ( '' < $_FILES['attachedfile']['name'] ) { 
                         // file name was given, but fetchMedia failed - show error when e.g. file size exceed maxuploadsize
                         $errorMessage .= $uploader->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     }
                     $obj->setVar('url', \Xmf\Request::getString('url', '', 'REQUEST'));
@@ -193,9 +193,9 @@ switch ($op) {
                     if ( '' < $_FILES['attachedimage']['name'] ) { 
                         // file name was given, but fetchMedia failed - show error when e.g. file size exceed maxuploadsize
                         $errorMessage .= $uploader_2->getErrors() . '<br>';
-                        $GLOBALS['xoopsTpl']->assign('error', $errorMessage);
+                        $GLOBALS['xoopsTpl']->assign('message_erreur', $errorMessage);
                         $form = $obj->getForm($donnee, true);
-                        $GLOBALS['xoopsTpl']->assign('form', $form->render());
+                        $GLOBALS['xoopsTpl']->assign('themeForm', $form->render());
                         break;
                     }
                     $obj->setVar('logourl', \Xmf\Request::getString('logo_img', '', 'REQUEST'));
@@ -268,7 +268,7 @@ switch ($op) {
             $errors = $obj->getHtmlErrors();
         }
         $form = $obj->getForm($donnee, true);
-        $xoopsTpl->assign('form', $form->render());
+        $xoopsTpl->assign('themeForm', $form->render());
         break;
 }
 require XOOPS_ROOT_PATH . '/footer.php';

--- a/templates/admin/tdmdownloads_admin_broken.tpl
+++ b/templates/admin/tdmdownloads_admin_broken.tpl
@@ -35,12 +35,12 @@
     <{/if}>
 <{/if}>
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/admin/tdmdownloads_admin_category.tpl
+++ b/templates/admin/tdmdownloads_admin_category.tpl
@@ -41,12 +41,12 @@
     <{/if}>
 <{/if}>
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/admin/tdmdownloads_admin_downloads.tpl
+++ b/templates/admin/tdmdownloads_admin_downloads.tpl
@@ -1,8 +1,8 @@
 <!-- Header -->
 <{include file='db:tdmdownloads_admin_header.tpl'}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 
 <div align="right">
@@ -184,8 +184,8 @@
     </table>
 <{/if}>
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
 <br>

--- a/templates/admin/tdmdownloads_admin_field.tpl
+++ b/templates/admin/tdmdownloads_admin_field.tpl
@@ -46,12 +46,12 @@
     <{/if}>
 <{/if}>
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/admin/tdmdownloads_admin_import.tpl
+++ b/templates/admin/tdmdownloads_admin_import.tpl
@@ -34,12 +34,12 @@
     <div class='intro'><{$smarty.const._AM_TDMDOWNLOADS_IMPORT_WARNING}></div>
 <{/if}>
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/admin/tdmdownloads_admin_modified.tpl
+++ b/templates/admin/tdmdownloads_admin_modified.tpl
@@ -87,12 +87,12 @@
 <{/if}>
 
 
-<{if $form}>
-    <{$form}>
+<{if $themeForm}>
+    <{$themeForm}>
 <{/if}>
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/admin/tdmdownloads_admin_permissions.tpl
+++ b/templates/admin/tdmdownloads_admin_permissions.tpl
@@ -11,8 +11,8 @@
 <{/if}>
 
 
-<{if $error}>
-    <div class='errorMsg'><{$error}></div>
+<{if $message_erreur}>
+    <div class='errorMsg'><{$message_erreur}></div>
 <{/if}>
 <br>
 <!-- Footer --><{include file='db:tdmdownloads_admin_footer.tpl'}>

--- a/templates/tdmdownloads_brokenfile.tpl
+++ b/templates/tdmdownloads_brokenfile.tpl
@@ -16,11 +16,11 @@
         </ul>
     </div>
 
-    <{if $error}>
-        <div class='errorMsg'><{$error}></div>
+    <{if $message_erreur}>
+        <div class='errorMsg'><{$message_erreur}></div>
     <{/if}>
 
     <!-- Submit form -->
-    <div class="tdmdownloads-submitform"><{$form}></div>
+    <div class="tdmdownloads-submitform"><{$themeForm}></div>
 
 </div>

--- a/templates/tdmdownloads_liste.tpl
+++ b/templates/tdmdownloads_liste.tpl
@@ -1,5 +1,4 @@
 <div class="tdmdownloads">
-
     <!-- Download logo-->
     <div class="tdmdownloads-logo center marg10">
         <a title="<{$smarty.const._MD_TDMDOWNLOADS_DOWNLOAD}>" href="<{$xoops_url}>/modules/tdmdownloads/index.php"><img src="<{$xoops_url}>/modules/tdmdownloads/assets/images/logo-en.gif" alt="<{$smarty.const._MD_TDMDOWNLOADS_DOWNLOAD}>"></a>
@@ -21,20 +20,26 @@
             <td class="head" align="center" style="width: 60px; vertical-align: middle;"><{$smarty.const._MD_TDMDOWNLOADS_SEARCH_NOTE}></td>
             <td class="head" align="center" style="width: 60px; vertical-align: middle;"><{$smarty.const._MD_TDMDOWNLOADS_SEARCH_HITS}></td>
         </tr>
-        <{foreach item=downloads from=$downloads}>
-            <{cycle values="odd,even" assign=class}>
-            <tr class="<{$class}>">
-                <td align="center" style="vertical-align: middle;"><a href="<{$xoops_url}>/modules/tdmdownloads/visit.php?cid=<{$downloads.cid}>&amp;lid=<{$downloads.lid}>" target="_blank"><img src="./assets/images/download.png" alt="<{$smarty.const._MD_TDMDOWNLOADS_SEARCH_DOWNLOAD}><{$downloads.title}>"
-                                                                                                                                                                                                  title="<{$smarty.const._MD_TDMDOWNLOADS_SEARCH_DOWNLOAD}><{$downloads.title}>"></a></td>
-                <td align="left" style="vertical-align: middle;"><a href="<{$xoops_url}>/modules/tdmdownloads/singlefile.php?cid=<{$downloads.cid}>&amp;lid=<{$downloads.lid}>" title="<{$downloads.title}>"><{$downloads.title}></a></td>
-                <td align="center" style="width: 32px; vertical-align: middle;"><img src="<{$downloads.imgurl}>" alt="<{$downloads.cat}>" title="<{$downloads.cat}>" width="30"></td>
-                <td align="left" style="vertical-align: middle;"><a href="<{$xoops_url}>/modules/tdmdownloads/viewcat.php?cid=<{$downloads.cid}>" target="_blank" title="<{$downloads.cat}>"><{$downloads.cat}></a></td>
-                <{foreach item=fielddata from=$downloads.fielddata}>
+        <{foreach item=download from=$search_list}>
+            <tr class='<{cycle values="odd,even"}>'>
+                <td align="center" style="vertical-align: middle;">
+					<a href="<{$xoops_url}>/modules/tdmdownloads/visit.php?cid=<{$download.cid}>&amp;lid=<{$download.lid}>" target="_blank"><img src="./assets/images/download.png" alt="<{$smarty.const._MD_TDMDOWNLOADS_SEARCH_DOWNLOAD}><{$download.title}>" title="<{$smarty.const._MD_TDMDOWNLOADS_SEARCH_DOWNLOAD}><{$download.title}>"></a>
+				</td>
+                <td align="left" style="vertical-align: middle;">
+					<a href="<{$xoops_url}>/modules/tdmdownloads/singlefile.php?cid=<{$download.cid}>&amp;lid=<{$download.lid}>" title="<{$download.title}>"><{$download.title}></a>
+				</td>
+                <td align="center" style="width: 32px; vertical-align: middle;">
+					<img src="<{$download.imgurl}>" alt="<{$download.cat}>" title="<{$download.cat}>" width="30">
+				</td>
+                <td align="left" style="vertical-align: middle;">
+					<a href="<{$xoops_url}>/modules/tdmdownloads/viewcat.php?cid=<{$download.cid}>" target="_blank" title="<{$download.cat}>"><{$download.cat}></a>
+				</td>
+                <{foreach item=fielddata from=$download.fielddata}>
                     <td align="left" style="vertical-align: middle;"><{$fielddata}></td>
                 <{/foreach}>
-                <td align="center" style="vertical-align: middle;"><{$downloads.date}></td>
-                <td align="center" style="vertical-align: middle;"><{$downloads.rating}></td>
-                <td align="center" style="vertical-align: middle;"><{$downloads.hits}></td>
+                <td align="center" style="vertical-align: middle;"><{$download.date}></td>
+                <td align="center" style="vertical-align: middle;"><{$download.rating}></td>
+                <td align="center" style="vertical-align: middle;"><{$download.hits}></td>
             </tr>
         <{/foreach}>
     </table>

--- a/templates/tdmdownloads_modfile.tpl
+++ b/templates/tdmdownloads_modfile.tpl
@@ -8,11 +8,11 @@
     <!-- Category path -->
     <div class="bold marg1 pad1"><{$navigation}></div>
 
-    <{if $error}>
-        <div class='errorMsg'><{$error}></div>
+    <{if message_erreur}>
+        <div class='tdmdownloads-errorMsg errorMsg'><{$message_erreur}></div>
     <{/if}>
 
     <!-- Submit form -->
-    <div class="tdmdownloads-submitform"><{$form}></div>
+    <div class="tdmdownloads-submitform"><{$themeForm}></div>
 
 </div>

--- a/templates/tdmdownloads_ratefile.tpl
+++ b/templates/tdmdownloads_ratefile.tpl
@@ -18,11 +18,11 @@
         </ul>
     </div>
 
-    <{if $error}>
-        <div class='errorMsg'><{$error}></div>
+    <{if $message_erreur}>
+        <div class='errorMsg'><{message_erreur}></div>
     <{/if}>
 
     <!-- Submit form -->
-    <div class="tdmdownloads-submitform"><{$form}></div>
+    <div class="tdmdownloads-submitform"><{$themeForm}></div>
 
 </div>

--- a/templates/tdmdownloads_submit.tpl
+++ b/templates/tdmdownloads_submit.tpl
@@ -18,11 +18,11 @@
         </ul>
     </div>
 
-    <{if $error}>
-        <div class='tdmdownloads-errorMsg errorMsg'><{$error}></div>
+    <{if $message_erreur}>
+        <div class='tdmdownloads-errorMsg errorMsg'><{$message_erreur}></div>
     <{/if}>
 
     <!-- Submit form -->
-    <div class="tdmdownloads-submitform"><{$form}></div>
+    <div class="tdmdownloads-submitform"><{$themeForm}></div>
 
 </div>


### PR DESCRIPTION
…y with existing themes

- adopted modfile.tpl (caused error if used together with blocks)
- skip captcha for xoopsUsers (members are skipped in class/download.php getForm)